### PR TITLE
[bug] forced dirspec dependency in common.config

### DIFF
--- a/src/leap/common/config/__init__.py
+++ b/src/leap/common/config/__init__.py
@@ -18,9 +18,13 @@
 Common configs
 """
 import os
+import platform
 
-from dirspec.basedir import get_xdg_config_home
-
+if platform.system() != "Windows":
+  from dirspec.basedir import get_xdg_config_home
+else:
+  def get_xdg_config_home():
+    return os.path.join(os.environ["APPDATA"], "Leap")
 
 def get_path_prefix(standalone=False):
     """


### PR DESCRIPTION
in win32 there is no dirspec module - provide appropriate path based on APPDATA when on windows
